### PR TITLE
rtas_errd/convert_dt_propos: fix warning message

### DIFF
--- a/rtas_errd/convert_dt_node_props.c
+++ b/rtas_errd/convert_dt_node_props.c
@@ -708,7 +708,8 @@ main(int argc, char *argv[]) {
 						drcname, DRC_NAME_LEN)) {
 					fprintf(stderr, "could not find the "
 						"drc-name corresponding to "
-						"drc-index 0x%08x\n", drcindex);
+						"drc-index 0x%08lx\n",
+						drc_tmp_idx);
 					return 4;
 				}
 				printf("%s\n", drcname);


### PR DESCRIPTION
In convert_dt_props::main(), the GCC-11 warned:
rtas_errd/convert_dt_node_props.c: In function ‘main’:
rtas_errd/convert_dt_node_props.c:709:41: warning: ‘drcindex’ may be used uninitialized [-Wmaybe-uninitialized]
  709 |                  fprintf(stderr, "could not find the "
      |                  ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  710 |                          "drc-name corresponding to "
      |                  ~~~~~~~~~~~~~~~~~~~~~~~~~~
  711 |                  "drc-index 0x%08x\n", drcindex);
      |                  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
rtas_errd/convert_dt_node_props.c:514:35: note: ‘drcindex’ declared here
  514 |         uint32_t interruptserver, drcindex;
      |                                   ^~~~~~~~
  CCLD     rtas_errd/convert_dt_node_props

it turns out, that the warning message was displaying the wrong drcindex
variable, in the mem context drc_tmp_idx holds the drcindex, it's the
index passed to mem_drcindex_to_drcname(). Use drc_tmp_idx variable for
warning message too.

Signed-off-by: Kamalesh Babulal <kamalesh@linux.ibm.com>